### PR TITLE
1 rewrite state to tick pressed keys

### DIFF
--- a/firmware/waddle/src/event.rs
+++ b/firmware/waddle/src/event.rs
@@ -1,0 +1,4 @@
+pub enum Event {
+    KeyCode(u8),
+}
+

--- a/firmware/waddle/src/event.rs
+++ b/firmware/waddle/src/event.rs
@@ -1,8 +1,6 @@
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub enum Event {
     KeyCode(u8),
-    // Adding another enum here breaks *everything*. Does not matter if it's used or not, this
-    // Breaks the USB setup. I can add enums in `Key` without problem, but here it breaks.
-    // Function
+    // Function(u8,u8,u8)
 }
 

--- a/firmware/waddle/src/event.rs
+++ b/firmware/waddle/src/event.rs
@@ -1,6 +1,0 @@
-#[derive(Eq, PartialEq, Copy, Clone)]
-pub enum Event {
-    KeyCode(u8),
-    // Function(u8,u8,u8)
-}
-

--- a/firmware/waddle/src/event.rs
+++ b/firmware/waddle/src/event.rs
@@ -1,5 +1,8 @@
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub enum Event {
     KeyCode(u8),
+    // Adding another enum here breaks *everything*. Does not matter if it's used or not, this
+    // Breaks the USB setup. I can add enums in `Key` without problem, but here it breaks.
+    // Function
 }
 

--- a/firmware/waddle/src/event.rs
+++ b/firmware/waddle/src/event.rs
@@ -1,3 +1,4 @@
+#[derive(Eq, PartialEq, Copy, Clone)]
 pub enum Event {
     KeyCode(u8),
 }

--- a/firmware/waddle/src/keyboard.rs
+++ b/firmware/waddle/src/keyboard.rs
@@ -18,7 +18,7 @@ use crate::state::State;
 pub type RowPinType = Pin<Output>;
 pub type ColPinType = Pin<Input<PullUp>>;
 
-pub const DELAY_MS: u16 = 10;
+pub const DELAY_MS: u16 = 20;
 
 pub enum ScanType {
     ROW2COL,
@@ -128,25 +128,13 @@ impl Keyboard {
             self.state.tick(&scan);
             let events = self.state.events();
 
+            self.set_leds();
             if !events.eq(&self.last_events) {
-                self.set_leds();
                 self.last_events = events.clone();
                 let kr: KeyboardReport = self.create_report(events);
                 self.hid_class.push_input(&kr);
             }
 
-            // if !state.eq(&self.last_state) {
-            //     // self.leds[0].set_low();
-            //     // self.leds[1].set_high();
-            //     let state = LAYOUT.apply_functions(&state);
-            //     self.set_leds(&state);
-            //     let kr: KeyboardReport = self.create_report(&state);
-            //     self.hid_class.push_input(&kr);
-            //     self.last_state = state;
-            // } else {
-            //     // self.leds[1].set_low();
-            //     // self.leds[0].set_high();
-            // }
             delay_ms(DELAY_MS);
         }
     }

--- a/firmware/waddle/src/keyboard.rs
+++ b/firmware/waddle/src/keyboard.rs
@@ -147,7 +147,7 @@ impl Keyboard {
             ScanType::COL2ROW => {
                 self.scan_col2row()
             }
-        }
+        };
     }
 
     fn scan_row2col(&mut self) -> Scan {

--- a/firmware/waddle/src/keyboard.rs
+++ b/firmware/waddle/src/keyboard.rs
@@ -170,8 +170,8 @@ impl Keyboard {
     fn set_leds(&mut self) {
         for (i, active) in self.state.led_state().iter().enumerate() {
             match *active {
-                true => Self::low(self.leds.get_mut(i).unwrap()),
-                false => Self::high(self.leds.get_mut(i).unwrap()),
+                true => Self::high(self.leds.get_mut(i).unwrap()),
+                false => Self::low(self.leds.get_mut(i).unwrap()),
             }
         }
     }

--- a/firmware/waddle/src/keyboard.rs
+++ b/firmware/waddle/src/keyboard.rs
@@ -195,6 +195,7 @@ impl Keyboard {
                 })
                 .filter(k::is_not_mod)
                 .enumerate() {
+                if i > 5 { break; }
                 key_codes[i] = k;
             }
 

--- a/firmware/waddle/src/keycode.rs
+++ b/firmware/waddle/src/keycode.rs
@@ -147,6 +147,10 @@ pub mod k {
         }
     }
 
+    pub fn is_not_mod(key: &u8) -> bool {
+        !is_mod(key)
+    }
+
     pub fn to_mod_bitfield(key: u8) -> u8 {
         match key {
             L_CTRL => 0b00000001,

--- a/firmware/waddle/src/layout.rs
+++ b/firmware/waddle/src/layout.rs
@@ -71,7 +71,7 @@ impl Layout {
     pub fn get(&self, button: usize) -> [Key; LAYERS] {
         let row = button / ROWS;
         let col = button % COLS;
-        let mut b = [Key; LAYERS];
+        let mut b = [Key::Dead; LAYERS];
         for layer in 0..LAYERS {
             b[layer] = self.get_key(layer, row, col);
         }
@@ -110,23 +110,23 @@ impl Layout {
     }
 
 
-    pub fn apply_functions(&self, state: &State) -> State {
-        let layer: u8 = state.pressed()
-            .iter()
-            .map(|p| LAYOUT.get_layer_mod(p))
-            .sum();
-
-        let mut s = state.clone();
-        state.pressed()
-            .iter()
-            .for_each(|p| {
-                match self.matrix.at(layer as usize)
-                    .at(p.row() as usize)
-                    .load_at(p.col() as usize) {
-                    Function(f) => f(&mut s),
-                    _ => {}
-                }
-            });
-        s
+    pub fn apply_functions(&self, state: &State) {
+        // let layer: u8 = state.pressed()
+        //     .iter()
+        //     .map(|p| LAYOUT.get_layer_mod(p))
+        //     .sum();
+        //
+        // let mut s = state.clone();
+        // state.pressed()
+        //     .iter()
+        //     .for_each(|p| {
+        //         match self.matrix.at(layer as usize)
+        //             .at(p.row() as usize)
+        //             .load_at(p.col() as usize) {
+        //             Function(f) => f(&mut s),
+        //             _ => {}
+        //         }
+        //     });
+        // s
     }
 }

--- a/firmware/waddle/src/layout.rs
+++ b/firmware/waddle/src/layout.rs
@@ -2,7 +2,7 @@ use avr_progmem::progmem;
 use avr_progmem::wrapper::ProgMem;
 
 use k::norde::se;
-use Key::{Dead, Function, KeyCode, LayerCh, LayerMo, PassThrough};
+use Key::{Dead, Function, KeyCode, LayerMo, PassThrough};
 
 use crate::keycode::k;
 use crate::keycode::k::layer;
@@ -68,16 +68,6 @@ impl Layout {
         Self { matrix: MATRIX }
     }
 
-    pub fn get(&self, button: usize) -> [Key; LAYERS] {
-        // let row = button / COLS;
-        // let col = button % COLS;
-        let mut b = [Key::Dead; LAYERS];
-        // for layer in 0..LAYERS {
-        //     b[layer] = self.get_key(layer, row, col);
-        // }
-        b
-    }
-
     pub fn get_key(&self, layer: u8, position: &Position) -> Key {
         self.matrix.at(layer as usize).at(position.row() as usize).at(position.col() as usize).load()
     }
@@ -91,21 +81,21 @@ impl Layout {
         }
     }
 
-    pub fn get_keycode(&self, layer: u8, position: &Position) -> Option<u8> {
-        match self.matrix.at(layer as usize)
-            .at(position.row() as usize)
-            .load_at(position.col() as usize) {
-            KeyCode(kc) => Some(kc),
-            PassThrough(l) => self.get_keycode(layer - l, position),
-            _ => None,
-        }
-    }
+    // pub fn get_keycode(&self, layer: u8, position: &Position) -> Option<u8> {
+    //     match self.matrix.at(layer as usize)
+    //         .at(position.row() as usize)
+    //         .load_at(position.col() as usize) {
+    //         KeyCode(kc) => Some(kc),
+    //         PassThrough(l) => self.get_keycode(layer - l, position),
+    //         _ => None,
+    //     }
+    // }
 
-    pub fn get_mod(&self, layer: u8, position: &Position) -> Option<u8> {
-        self.get_keycode(layer, position).filter(k::is_mod).map(k::to_mod_bitfield)
-    }
-
-    pub fn get_non_mod(&self, layer: u8, position: &Position) -> Option<u8> {
-        self.get_keycode(layer, position).filter(|u| !k::is_mod(u))
-    }
+    // pub fn get_mod(&self, layer: u8, position: &Position) -> Option<u8> {
+    //     self.get_keycode(layer, position).filter(k::is_mod).map(k::to_mod_bitfield)
+    // }
+    //
+    // pub fn get_non_mod(&self, layer: u8, position: &Position) -> Option<u8> {
+    //     self.get_keycode(layer, position).filter(|u| !k::is_mod(u))
+    // }
 }

--- a/firmware/waddle/src/layout.rs
+++ b/firmware/waddle/src/layout.rs
@@ -67,6 +67,21 @@ impl Layout {
     pub fn new() -> Self {
         Self { matrix: MATRIX }
     }
+
+    pub fn get(&self, button: usize) -> [Key; LAYERS] {
+        let row = button / ROWS;
+        let col = button % COLS;
+        let mut b = [Key; LAYERS];
+        for layer in 0..LAYERS {
+            b[layer] = self.get_key(layer, row, col);
+        }
+        b
+    }
+
+    pub fn get_key(&self, layer: usize, row: usize, col: usize) -> Key {
+        self.matrix.at(layer).at(row).at(col).load()
+    }
+
     pub fn get_layer_mod(&self, position: &Position) -> u8 {
         match self.matrix.at(0)
             .at(position.row() as usize)

--- a/firmware/waddle/src/layout.rs
+++ b/firmware/waddle/src/layout.rs
@@ -69,17 +69,17 @@ impl Layout {
     }
 
     pub fn get(&self, button: usize) -> [Key; LAYERS] {
-        let row = button / ROWS;
-        let col = button % COLS;
+        // let row = button / COLS;
+        // let col = button % COLS;
         let mut b = [Key::Dead; LAYERS];
-        for layer in 0..LAYERS {
-            b[layer] = self.get_key(layer, row, col);
-        }
+        // for layer in 0..LAYERS {
+        //     b[layer] = self.get_key(layer, row, col);
+        // }
         b
     }
 
-    pub fn get_key(&self, layer: usize, row: usize, col: usize) -> Key {
-        self.matrix.at(layer).at(row).at(col).load()
+    pub fn get_key(&self, layer: u8, position: &Position) -> Key {
+        self.matrix.at(layer as usize).at(position.row() as usize).at(position.col() as usize).load()
     }
 
     pub fn get_layer_mod(&self, position: &Position) -> u8 {
@@ -107,26 +107,5 @@ impl Layout {
 
     pub fn get_non_mod(&self, layer: u8, position: &Position) -> Option<u8> {
         self.get_keycode(layer, position).filter(|u| !k::is_mod(u))
-    }
-
-
-    pub fn apply_functions(&self, state: &State) {
-        // let layer: u8 = state.pressed()
-        //     .iter()
-        //     .map(|p| LAYOUT.get_layer_mod(p))
-        //     .sum();
-        //
-        // let mut s = state.clone();
-        // state.pressed()
-        //     .iter()
-        //     .for_each(|p| {
-        //         match self.matrix.at(layer as usize)
-        //             .at(p.row() as usize)
-        //             .load_at(p.col() as usize) {
-        //             Function(f) => f(&mut s),
-        //             _ => {}
-        //         }
-        //     });
-        // s
     }
 }

--- a/firmware/waddle/src/main.rs
+++ b/firmware/waddle/src/main.rs
@@ -49,6 +49,7 @@ mod keyboard;
 mod position;
 mod macros;
 mod scan;
+mod event;
 
 /// Wrapper around a usb-cdc SerialPort
 /// to be able to use the `write!()` macro with it

--- a/firmware/waddle/src/main.rs
+++ b/firmware/waddle/src/main.rs
@@ -8,19 +8,14 @@
 use core::fmt::{Result, Write};
 use core::panic::PanicInfo;
 
-use arduino_hal::{delay_ms,
-                  entry,
-                  Peripherals,
-                  pins,
-                  port::{
-                      mode::{
-                          Input,
-                          Output,
-                          PullUp,
-                      },
-                      Pin,
-                  },
-};
+use arduino_hal::{delay_ms, entry, Peripherals, pins, Pins, port::{
+    mode::{
+        Input,
+        Output,
+        PullUp,
+    },
+    Pin,
+}};
 use arduino_hal::hal::port::Dynamic;
 use arduino_hal::port::mode::{AnyInput, Floating};
 use arduino_hal::port::PinMode;
@@ -66,7 +61,7 @@ impl<'a> Write for DebugPort<'a> {
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take().unwrap();
-    let pins = pins!(peripherals);
+    let pins: Pins = pins!(peripherals);
     let pll = peripherals.PLL;
     let usb = peripherals.USB_DEVICE;
 
@@ -80,52 +75,71 @@ fn main() -> ! {
     // Wait until the bit is set
     while pll.pllcsr.read().plock().bit_is_clear() {}
 
-    let usb_bus = unsafe {
-        static mut USB_BUS: Option<UsbBusAllocator<UsbBus>> = None;
-        &*USB_BUS.insert(UsbBus::new(usb))
-    };
+    unsafe {
+        let usb_bus = unsafe {
+            static mut UB: Option<UsbBusAllocator<UsbBus>> = None;
+            &*UB.insert(UsbBus::new(usb))
+        };
+        USB_BUS = Some(usb_bus);
+    }
 
-    // Set up the USB Communications Class Device driver for debugging
-    let mut debug_port = DebugPort(SerialPort::new(usb_bus));
-
-
-    let hid_class = HIDClass::new(&usb_bus, KeyboardReport::desc(), 1);
-    let usb_device = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27db))
-        .manufacturer("qwelyt")
-        .product("waddle")
-        .device_class(3) // HID
-        .device_sub_class(1) // Keyboard
-        .build();
-
-    let rows = vec![
-        pins.a2.into_output_high().downgrade(),
-        pins.a3.into_output_high().downgrade(),
-        pins.d2.into_output_high().downgrade(),
-        pins.d3.into_output_high().downgrade(),
-    ];
-    let cols = vec![
-        pins.a1.into_pull_up_input().downgrade(),
-        pins.a0.into_pull_up_input().downgrade(),
-        pins.d15.into_pull_up_input().downgrade(),
-        pins.d16.into_pull_up_input().downgrade(),
-        pins.d14.into_pull_up_input().downgrade(),
-        pins.d10.into_pull_up_input().downgrade(),
-        pins.d9.into_pull_up_input().downgrade(),
-        pins.d8.into_pull_up_input().downgrade(),
-        pins.d7.into_pull_up_input().downgrade(),
-        pins.d6.into_pull_up_input().downgrade(),
-        pins.d5.into_pull_up_input().downgrade(),
-        pins.d4.into_pull_up_input().downgrade(),
-    ];
-
-    let mut leds = vec![
-        pins.led_rx.into_output().downgrade(),
-        pins.rx.into_output().downgrade(),
-        pins.tx.into_output().downgrade(),
-    ];
-    leds.iter_mut().map(|p| p.set_high());
 
     unsafe {
+        // Set up the USB Communications Class Device driver for debugging
+        let mut debug_port = DebugPort(SerialPort::new(USB_BUS.unwrap()));
+
+        init_keyboard(pins);
+
+        write!(debug_port, "hello").unwrap();
+        interrupt::enable()
+    };
+
+
+    loop {
+        sleep();
+    }
+}
+
+static mut USB_BUS: Option<&UsbBusAllocator<UsbBus>> = None;
+static mut KEYBOARD: Option<Keyboard> = None;
+
+fn init_keyboard(pins: Pins) {
+    unsafe {
+        let hid_class = HIDClass::new(USB_BUS.unwrap(), KeyboardReport::desc(), 1);
+        let usb_device = UsbDeviceBuilder::new(USB_BUS.unwrap(), UsbVidPid(0x16c0, 0x27db))
+            .manufacturer("qwelyt")
+            .product("waddle")
+            .device_class(3) // HID
+            .device_sub_class(1) // Keyboard
+            .build();
+        let rows = vec![
+            pins.a2.into_output_high().downgrade(),
+            pins.a3.into_output_high().downgrade(),
+            pins.d2.into_output_high().downgrade(),
+            pins.d3.into_output_high().downgrade(),
+        ];
+        let cols = vec![
+            pins.a1.into_pull_up_input().downgrade(),
+            pins.a0.into_pull_up_input().downgrade(),
+            pins.d15.into_pull_up_input().downgrade(),
+            pins.d16.into_pull_up_input().downgrade(),
+            pins.d14.into_pull_up_input().downgrade(),
+            pins.d10.into_pull_up_input().downgrade(),
+            pins.d9.into_pull_up_input().downgrade(),
+            pins.d8.into_pull_up_input().downgrade(),
+            pins.d7.into_pull_up_input().downgrade(),
+            pins.d6.into_pull_up_input().downgrade(),
+            pins.d5.into_pull_up_input().downgrade(),
+            pins.d4.into_pull_up_input().downgrade(),
+        ];
+
+        let mut leds = vec![
+            pins.led_rx.into_output().downgrade(),
+            pins.rx.into_output().downgrade(),
+            pins.tx.into_output().downgrade(),
+        ];
+        leds.iter_mut().map(|p| p.set_high());
+
         KEYBOARD = Some(Keyboard::row2col(
             usb_device,
             hid_class,
@@ -134,16 +148,7 @@ fn main() -> ! {
             leds,
         ))
     }
-
-    unsafe { interrupt::enable() };
-
-    write!(debug_port, "hello").unwrap();
-    loop {
-        sleep();
-    }
 }
-
-static mut KEYBOARD: Option<Keyboard> = None;
 
 #[interrupt(atmega32u4)]
 fn USB_GEN() {

--- a/firmware/waddle/src/main.rs
+++ b/firmware/waddle/src/main.rs
@@ -48,6 +48,7 @@ mod keycode;
 mod keyboard;
 mod position;
 mod macros;
+mod scan;
 
 /// Wrapper around a usb-cdc SerialPort
 /// to be able to use the `write!()` macro with it

--- a/firmware/waddle/src/main.rs
+++ b/firmware/waddle/src/main.rs
@@ -81,10 +81,7 @@ fn main() -> ! {
             &*UB.insert(UsbBus::new(usb))
         };
         USB_BUS = Some(usb_bus);
-    }
 
-
-    unsafe {
         // Set up the USB Communications Class Device driver for debugging
         let mut debug_port = DebugPort(SerialPort::new(USB_BUS.unwrap()));
 

--- a/firmware/waddle/src/main.rs
+++ b/firmware/waddle/src/main.rs
@@ -44,7 +44,6 @@ mod keyboard;
 mod position;
 mod macros;
 mod scan;
-mod event;
 
 /// Wrapper around a usb-cdc SerialPort
 /// to be able to use the `write!()` macro with it

--- a/firmware/waddle/src/main.rs
+++ b/firmware/waddle/src/main.rs
@@ -118,23 +118,12 @@ fn main() -> ! {
         pins.d4.into_pull_up_input().downgrade(),
     ];
 
-    // let rows = vec![pins.a3.into_output().downgrade()];
-    // let cols = vec![pins.d2.into_output().downgrade()];
-
-    // let rows = vec![
-    //     pins.a3.into_output_high().downgrade(),
-    //     pins.a2.into_output_high().downgrade(),
-    // ];
-    // let cols = vec![
-    //     pins.d2.into_pull_up_input().downgrade(),
-    //     pins.d3.into_pull_up_input().downgrade(),
-    // ];
     let mut leds = vec![
         pins.led_rx.into_output().downgrade(),
         pins.rx.into_output().downgrade(),
         pins.tx.into_output().downgrade(),
     ];
-    leds.iter_mut().map(|p| p.set_low());
+    leds.iter_mut().map(|p| p.set_high());
 
     unsafe {
         KEYBOARD = Some(Keyboard::row2col(

--- a/firmware/waddle/src/position.rs
+++ b/firmware/waddle/src/position.rs
@@ -1,4 +1,6 @@
 pub mod position {
+    use crate::layout::COLS;
+
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
     pub struct Position {
         row: u8,
@@ -8,6 +10,12 @@ pub mod position {
     impl Position {
         pub const fn new(row: u8, col: u8) -> Self {
             Self { row, col }
+        }
+
+        pub fn from(i: usize) -> Self {
+            let r = i / COLS;
+            let c = i % COLS;
+            Self::new(r as u8, c as u8)
         }
 
         pub fn row(&self) -> u8 {

--- a/firmware/waddle/src/position.rs
+++ b/firmware/waddle/src/position.rs
@@ -1,21 +1,17 @@
 pub mod position {
     use crate::layout::COLS;
 
-    #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+    #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Position {
         row: u8,
         col: u8,
     }
 
     impl Position {
-        pub const fn new(row: u8, col: u8) -> Self {
-            Self { row, col }
-        }
-
         pub fn from(i: usize) -> Self {
-            let r = i / COLS;
-            let c = i % COLS;
-            Self::new(r as u8, c as u8)
+            let row = i / COLS;
+            let col = i % COLS;
+            Self { row: row as u8, col: col as u8 }
         }
 
         pub fn row(&self) -> u8 {
@@ -23,16 +19,6 @@ pub mod position {
         }
         pub fn col(&self) -> u8 {
             self.col
-        }
-    }
-
-    impl hash32::Hash for Position {
-        fn hash<H>(&self, state: &mut H)
-            where
-                H: hash32::Hasher,
-        {
-            self.row.hash(state);
-            self.col.hash(state);
         }
     }
 }

--- a/firmware/waddle/src/scan.rs
+++ b/firmware/waddle/src/scan.rs
@@ -17,7 +17,7 @@ impl Scan {
 
     pub fn is_pressed(&self, button: usize) -> bool {
         let c = button % COLS;
-        let r = botton / ROWS;
+        let r = button / ROWS;
         let p = self.pressed[r] & (1 << c);
         p > 0
     }

--- a/firmware/waddle/src/scan.rs
+++ b/firmware/waddle/src/scan.rs
@@ -17,7 +17,7 @@ impl Scan {
 
     pub fn is_pressed(&self, button: usize) -> bool {
         let c = button % COLS;
-        let r = button / ROWS;
+        let r = button / COLS;
         let p = self.pressed[r] & (1 << c);
         p > 0
     }

--- a/firmware/waddle/src/scan.rs
+++ b/firmware/waddle/src/scan.rs
@@ -1,0 +1,24 @@
+use crate::layout::{COLS, ROWS};
+
+pub struct Scan {
+    pressed: [u16; ROWS],
+}
+
+impl Scan {
+    pub fn new() -> Self {
+        Self {
+            pressed: [0; ROWS]
+        }
+    }
+
+    pub fn set_pressed(&mut self, row: usize, col: usize) {
+        self.pressed[row] = self.pressed[row] | (1 << col)
+    }
+
+    pub fn is_pressed(&self, button: usize) -> bool {
+        let c = button % COLS;
+        let r = botton / ROWS;
+        let p = self.pressed[r] & (1 << c);
+        p > 0
+    }
+}

--- a/firmware/waddle/src/state.rs
+++ b/firmware/waddle/src/state.rs
@@ -5,6 +5,7 @@ use crate::keyboard::DELAY_MS;
 use crate::layout::{BUTTONS, Key, LAYERS, LAYOUT, LEDS};
 use crate::position::position::Position;
 use crate::scan::Scan;
+use crate::vec;
 
 pub struct State {
     pressed: [u8; BUTTONS],
@@ -86,6 +87,7 @@ impl State {
     fn get_key(&self, position: &Position, layer: u8) -> Option<Event> {
         match LAYOUT.get_key(layer, position) {
             Key::KeyCode(kc) => Some(Event::KeyCode(kc)),
+            // Key::KeyCode(kc) => None,
             Key::PassThrough(go_down) => self.get_key(position, layer - go_down),
             _ => None
         }

--- a/firmware/waddle/src/state.rs
+++ b/firmware/waddle/src/state.rs
@@ -1,5 +1,3 @@
-use core::intrinsics::offset;
-
 use heapless::Vec;
 
 use crate::event::Event;
@@ -8,9 +6,7 @@ use crate::layout::{BUTTONS, Key, LAYERS, LAYOUT, LEDS};
 use crate::position::position::Position;
 use crate::scan::Scan;
 
-pub const STATE: State = State::new();
-
-struct State {
+pub struct State {
     pressed: [u8; BUTTONS],
     released: [u8; BUTTONS],
     leds: u8,
@@ -61,11 +57,11 @@ impl State {
         let layer: u8 = buttons.iter()
             .map(|ks| ks.iter()
                 .map(|k| match k {
-                    Key::LayerMo(l) => l,
+                    Key::LayerMo(layer) => *layer,
                     _ => 0,
                 })
-                .sum()
-            ).sum();
+                .sum::<u8>()
+            ).sum::<u8>();
         // 2. Get all keys on that layer, or lower if current is PassThrough
         let keys: Vec<Key, BUTTONS> = buttons.iter()
             .map(|ks| self.get_key(ks, layer))
@@ -93,13 +89,13 @@ impl State {
         events
     }
     fn ms_to_ticks(ms: u8) -> u8 {
-        ms / DELAY_MS
+        ms / DELAY_MS as u8
     }
     fn get_key(&self, keys: &[Key; 4], layer: u8) -> Option<Key> {
-        match keys[layer] {
+        match keys[layer as usize] {
             Key::Dead => None,
-            Key::PassThrough(l) => self.get_key(keys, layer - l),
-            _ => Some(ks[layer])
+            Key::PassThrough(go_down) => self.get_key(keys, layer - go_down),
+            _ => Some(keys[layer as usize])
         }
     }
 


### PR DESCRIPTION
Rewrite how the scanning works.

Instead of using scan rounds and see what is pressed from that, put every key in an array and count how many `tick`s that have passed since it was first pressed. This makes it possible to see for how long a key has been held, which paves way for things like `Key::OnHold`.

This required a rather large rewrite of how we check for keys. And future key variants will probably require more. But we are now one step closer to more fun key variants!

Also, redid a bit of what is stored on the stack to try and reduce usage, giving us more playroom to work with.

Closes #1 